### PR TITLE
Add Chapters Data To Books Table

### DIFF
--- a/app/services/create_books_service.rb
+++ b/app/services/create_books_service.rb
@@ -14,7 +14,7 @@ class CreateBooksService
           position: book["position"],
           chapters_data: book["chapter_count"].times.map do |index|
             chapter = index + 1
-            { chapter_number: chapter, completed: false, completed_date: nil }
+            { chapter_number: chapter, completed_at: nil }
           end
         )
       end

--- a/app/services/create_books_service.rb
+++ b/app/services/create_books_service.rb
@@ -11,7 +11,11 @@ class CreateBooksService
           name: book["name"],
           slug: book["slug"],
           reading_log: @reading_log,
-          position: book["position"]
+          position: book["position"],
+          chapters_data: book["chapter_count"].times.map do |index|
+            chapter = index + 1
+            { chapter_number: chapter, completed: false, completed_date: nil }
+          end
         )
       end
     rescue => e

--- a/app/views/base/index.html.erb
+++ b/app/views/base/index.html.erb
@@ -1,6 +1,15 @@
 <%= button_to "Log out", log_out_path, method: :delete %>
-<%= current_user.email %>
+<div class="mb-4">
+  <%= current_user.email %>
+</div>
 
 <% current_user.reading_log.books.each do |book| %>
-  <div><%= book.name %></div>
+  <div class="border-b py-4">
+    <div class="font-semibold mb-2 text-lg"><%= book.name %></div>
+    <% book.chapters_data.each do |chapter_data| %>
+      <span class="<%= 'bg-green-700 border-green-700 text-white' if chapter_data["completed"] %> text-center w-[40px] mb-2 opacity-50 p-1 border border-gray-300 rounded inline-block">
+        <%= chapter_data["chapter_number"] %>
+      </span>
+    <% end %>
+  </div>
 <% end %>

--- a/db/migrate/20240413163526_add_chapters_data_to_books.rb
+++ b/db/migrate/20240413163526_add_chapters_data_to_books.rb
@@ -1,0 +1,5 @@
+class AddChaptersDataToBooks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :books, :chapters_data, :jsonb, null: false
+  end
+end

--- a/db/migrate/20240413163526_add_chapters_data_to_books.rb
+++ b/db/migrate/20240413163526_add_chapters_data_to_books.rb
@@ -1,5 +1,6 @@
 class AddChaptersDataToBooks < ActiveRecord::Migration[7.1]
   def change
     add_column :books, :chapters_data, :jsonb, null: false
+    add_index :books, :chapters_data
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_13_163526) do
     t.datetime "updated_at", null: false
     t.integer "position", null: false
     t.jsonb "chapters_data", null: false
+    t.index ["chapters_data"], name: "index_books_on_chapters_data"
     t.index ["position", "reading_log_id"], name: "index_books_on_position_and_reading_log_id", unique: true
     t.index ["reading_log_id", "name"], name: "index_books_on_reading_log_id_and_name", unique: true
     t.index ["slug", "reading_log_id"], name: "index_books_on_slug_and_reading_log_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_13_154754) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_13_163526) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_13_154754) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position", null: false
+    t.jsonb "chapters_data", null: false
     t.index ["position", "reading_log_id"], name: "index_books_on_position_and_reading_log_id", unique: true
     t.index ["reading_log_id", "name"], name: "index_books_on_reading_log_id_and_name", unique: true
     t.index ["slug", "reading_log_id"], name: "index_books_on_slug_and_reading_log_id", unique: true


### PR DESCRIPTION
Adds a `chapters_data` jsonb column to the `books` table to store completed chapter data for each book.

The alternative to this is to have each chapter be an actual record (see PR draft here #4), but that's quite a ton of records to create, so it would need to be optimized to create only when necessary? Jsonb gives some flexibility for now