### PR TITLE
Group reading logs

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -40,7 +40,7 @@
   .field_with_errors .form-input {}
 
   .container--flash {
-    @apply w-full max-w-[90%] xs:w-fit flex text-wrap xs:text-nowrap space-x-2.5 items-center  z-[999] text-center transition-opacity duration-200 ease-out rounded-lg text-white py-3.5 pl-4 px-5 -translate-x-1/2 opacity-0 left-1/2 bottom-10 xs:bottom-[initial] top-[initial] xs:top-11 fixed;
+    @apply w-full max-w-[90%] xs:w-fit flex text-wrap xs:text-nowrap space-x-2.5 items-center  z-[999] text-center transition-opacity duration-200 ease-out rounded-lg text-white py-3.5 pl-4 px-5 -translate-x-1/2 opacity-0 left-1/2 h-fit bottom-10 xs:bottom-[initial] top-[initial] xs:top-11 fixed;
   }
 
   .container--flash.active {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -14,11 +14,11 @@
   }
 
   .form-input {
-    @apply w-full  !placeholder-neutral-400 !mt-0.5 border-0 !px-3.5 !text-lg !py-2 !rounded-lg focus:!ring-neutral-600 focus:!border-neutral-600 !border-neutral-300;
+    @apply w-full bg-white !placeholder-neutral-400 !mt-0.5 border-0 !px-3.5 !text-lg !py-2 !rounded-lg focus:!ring-neutral-600 focus:!border-neutral-600 !border-neutral-300;
   }
 
   .form-select {
-    @apply w-full !mt-0.5 border-0 !px-3.5 !text-lg !py-2 !rounded-lg focus:!ring-neutral-600 focus:!border-neutral-600 !border-neutral-300;
+    @apply w-full bg-white !mt-0.5 border-0 !px-3.5 !text-lg !py-2 !rounded-lg focus:!ring-neutral-600 focus:!border-neutral-600 !border-neutral-300;
   }
 
   .btn {

--- a/app/components/auth_header_component.rb
+++ b/app/components/auth_header_component.rb
@@ -2,7 +2,7 @@
 
 class AuthHeaderComponent < ViewComponent::Base
   erb_template <<-ERB
-    <div class="text-center flex justify-center flex-col items-center mb-5 space-y-2">
+    <div class="mt-16 text-center flex justify-center flex-col items-center mb-5 space-y-2">
       <%= render "shared/logo", width: '60px' %>
       <h1 class="text-4xl font-bold"><%= @title %></h1>
       <% if @subtitle %>

--- a/app/components/input_component.rb
+++ b/app/components/input_component.rb
@@ -2,10 +2,10 @@
 
 class InputComponent < ViewComponent::Base
   erb_template <<-ERB
-    <%= @form.send(field_type, @id_and_name, class: "form-input " + @custom_classes, required: @required, placeholder: @placeholder, autofocus: @autofocus) %>
+    <%= @form.send(field_type, @id_and_name, class: "form-input " + @custom_classes, required: @required, placeholder: @placeholder, autofocus: @autofocus, disabled: @disabled) %>
   ERB
 
-  def initialize(form:, type:, id_and_name:, required: false, custom_classes: "", placeholder: nil, autofocus: false)
+  def initialize(form:, type:, id_and_name:, required: false, custom_classes: "", placeholder: nil, autofocus: false, disabled: false)
     @form = form
     @type = type
     @id_and_name = id_and_name
@@ -13,6 +13,7 @@ class InputComponent < ViewComponent::Base
     @custom_classes = custom_classes
     @placeholder = placeholder
     @autofocus = autofocus
+    @disabled = disabled
   end
 
   def field_type

--- a/app/components/loading_spinner_component.rb
+++ b/app/components/loading_spinner_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class LoadingSpinnerComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <div
+      class="mt-10 block mx-auto h-16 w-16 animate-spin rounded-full border-8 border-solid border-neutral-300 border-current border-e-transparent align-[-0.125em] text-surface motion-reduce:animate-[spin_1.5s_linear_infinite] dark:text-white"
+      role="status">
+      <span
+        class="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]"
+        >Loading...</span
+      >
+    </div>
+  ERB
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   private
 
   def authenticate_user!
-    redirect_to sign_in_path, alert: "You must be signed in" unless user_signed_in?
+    redirect_to sign_in_path(dest: request.path), alert: "You must be signed in" unless user_signed_in?
   end
 
   def require_no_user!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,8 @@ class ApplicationController < ActionController::Base
   private
 
   def authenticate_user!
-    redirect_to sign_in_path(dest: request.path), alert: "You must be signed in" unless user_signed_in?
+    dest = request.path == root_path ? nil : request.path
+    redirect_to sign_in_path(dest: dest), alert: "You must be signed in" unless user_signed_in?
   end
 
   def require_no_user!

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -94,6 +94,47 @@ class ReadingLogsController < ApplicationController
 
   def join_invite
     flash.clear
+
+    if current_user.confirmed_at.nil?
+      flash[:alert] = "Confirm your email before joining"
+      redirect_to email_confirmation_path
+    else
+      @reading_log = ReadingLog.find_by(slug: params[:slug])
+      if @reading_log.user == current_user
+        flash[:notice] = "You are the owner of this reading log"
+        redirect_to reading_log_path(@reading_log)
+      elsif @child_reading_log = @reading_log.child_reading_logs.where(user: current_user).first
+        flash[:notice] = "You are already part of this reading log"
+        redirect_to reading_log_path(@child_reading_log)
+      else
+        @child_reading_log = current_user.reading_logs.new(
+          name: @reading_log.name,
+          is_entire_bible: @reading_log.is_entire_bible,
+          books_count: @reading_log.books_count,
+          template_reading_log: @reading_log,
+        )
+        @reading_log.books.each do |book|
+          @child_reading_log.books.new(
+            name: book["name"],
+            slug: book["slug"],
+            reading_log: @reading_log,
+            position: book["position"],
+            chapters_count: book["chapters_count"],
+            chapters_data: book["chapters_count"].times.map do |index|
+              chapter = index + 1
+              { chapter_number: chapter, completed_at: nil }
+            end,
+          )
+        end
+        if @child_reading_log.save
+          flash[:notice] = "Adding you to the reading log..."
+          redirect_to reading_log_path(@child_reading_log)
+        else
+          flash[:alert] = "Something went wrong, try again."
+          redirect_to root_path
+        end
+      end
+    end
   end
 
   def destroy

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -100,39 +100,44 @@ class ReadingLogsController < ApplicationController
       redirect_to email_confirmation_path
     else
       @reading_log = ReadingLog.find_by(slug: params[:slug])
-      if @reading_log.user == current_user
-        flash[:notice] = "You are the owner of this reading log"
-        redirect_to reading_log_path(@reading_log)
-      elsif @child_reading_log = @reading_log.child_reading_logs.where(user: current_user).first
-        flash[:notice] = "You are already part of this reading log"
-        redirect_to reading_log_path(@child_reading_log)
-      else
-        @child_reading_log = current_user.reading_logs.new(
-          name: @reading_log.name,
-          is_entire_bible: @reading_log.is_entire_bible,
-          books_count: @reading_log.books_count,
-          template_reading_log: @reading_log,
-        )
-        @reading_log.books.each do |book|
-          @child_reading_log.books.new(
-            name: book["name"],
-            slug: book["slug"],
-            reading_log: @reading_log,
-            position: book["position"],
-            chapters_count: book["chapters_count"],
-            chapters_data: book["chapters_count"].times.map do |index|
-              chapter = index + 1
-              { chapter_number: chapter, completed_at: nil }
-            end,
-          )
-        end
-        if @child_reading_log.save
-          flash[:notice] = "Adding you to the reading log..."
+      if @reading_log.present?
+        if @reading_log.user == current_user
+          flash[:notice] = "You are the owner of this reading log"
+          redirect_to reading_log_path(@reading_log)
+        elsif @child_reading_log = @reading_log.child_reading_logs.where(user: current_user).first
+          flash[:notice] = "You are already part of this reading log"
           redirect_to reading_log_path(@child_reading_log)
         else
-          flash[:alert] = "Something went wrong, try again."
-          redirect_to root_path
+          @child_reading_log = current_user.reading_logs.new(
+            name: @reading_log.name,
+            is_entire_bible: @reading_log.is_entire_bible,
+            books_count: @reading_log.books_count,
+            template_reading_log: @reading_log,
+          )
+          @reading_log.books.each do |book|
+            @child_reading_log.books.new(
+              name: book["name"],
+              slug: book["slug"],
+              reading_log: @reading_log,
+              position: book["position"],
+              chapters_count: book["chapters_count"],
+              chapters_data: book["chapters_count"].times.map do |index|
+                chapter = index + 1
+                { chapter_number: chapter, completed_at: nil }
+              end,
+            )
+          end
+          if @child_reading_log.save
+            flash[:notice] = "Adding you to the reading log..."
+            redirect_to reading_log_path(@child_reading_log)
+          else
+            flash[:alert] = "Something went wrong, try again."
+            redirect_to root_path
+          end
         end
+      else
+        flash[:alert] = "That reading log doesn't exist"
+        redirect_to root_path
       end
     end
   end

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -2,6 +2,8 @@ class ReadingLogsController < ApplicationController
   before_action :set_reading_log, only: [:update, :show, :settings, :destroy]
   before_action :set_books_data, only: [:new, :create]
 
+  skip_before_action :authenticate_user!, only: [:invite]
+
   def index
     @skip_turbo_cache_control = true
     @has_completed_status = params[:status] == "completed"
@@ -78,6 +80,10 @@ class ReadingLogsController < ApplicationController
   end
 
   def settings
+  end
+
+  def invite
+    @reading_log = ReadingLog.find_by(slug: params[:slug])
   end
 
   def destroy

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -101,7 +101,9 @@ class ReadingLogsController < ApplicationController
 
     if @reading_log
       if user_signed_in?
-        @is_reading_log_member = @reading_log.user == current_user || @reading_log.child_reading_logs.where(user: current_user).exists?
+        unless @is_reading_log_owner = @reading_log.user == current_user
+          @is_reading_log_member = @reading_log.child_reading_logs.where(user: current_user).exists?
+        end
       end
     end
   end

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -141,7 +141,7 @@ class ReadingLogsController < ApplicationController
             )
           end
           if @child_reading_log.save
-            flash[:notice] = "You've been adding to the reading log!"
+            flash[:notice] = "You've been added to the reading log!"
             redirect_to reading_log_path(@child_reading_log)
           else
             flash[:alert] = "Something went wrong, try again."

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -143,6 +143,8 @@ class ReadingLogsController < ApplicationController
               end,
             )
           end
+          @reading_log.update(is_group_reading_log: true) unless @reading_log.is_group_reading_log
+
           if @child_reading_log.save
             flash[:notice] = "You've been added to the reading log!"
             redirect_to reading_log_path(@child_reading_log)
@@ -159,6 +161,12 @@ class ReadingLogsController < ApplicationController
   end
 
   def destroy
+    if @reading_log.template_reading_log.present?
+      if @reading_log.template_reading_log.child_reading_logs.where.not(id: @reading_log.id).empty?
+        @reading_log.template_reading_log.update(is_group_reading_log: false)
+      end
+    end
+
     if @reading_log.destroy
       redirect_to root_path, notice: "Reading Log was deleted."
     else

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -92,6 +92,10 @@ class ReadingLogsController < ApplicationController
     end
   end
 
+  def join_invite
+    flash.clear
+  end
+
   def destroy
     if @reading_log.destroy
       redirect_to root_path, notice: "Reading Log was deleted."

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -1,5 +1,5 @@
 class ReadingLogsController < ApplicationController
-  before_action :set_reading_log, only: [:update, :show, :settings, :destroy]
+  before_action :set_reading_log, only: [:update, :settings, :destroy]
   before_action :set_books_data, only: [:new, :create]
 
   skip_before_action :authenticate_user!, only: [:invite]
@@ -74,6 +74,7 @@ class ReadingLogsController < ApplicationController
   end
 
   def show
+    @reading_log = ReadingLog.includes(:template_reading_log, child_reading_logs: :user).find(params[:id])
     @skip_turbo_cache_control = true
 
     @has_pending_status = params[:status] == "pending"

--- a/app/controllers/reading_logs_controller.rb
+++ b/app/controllers/reading_logs_controller.rb
@@ -84,6 +84,12 @@ class ReadingLogsController < ApplicationController
 
   def invite
     @reading_log = ReadingLog.find_by(slug: params[:slug])
+
+    if @reading_log
+      if user_signed_in?
+        @is_reading_log_member = @reading_log.user == current_user || @reading_log.child_reading_logs.where(user: current_user).exists?
+      end
+    end
   end
 
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,7 @@ class SessionsController < ApplicationController
   before_action :require_no_user!, except: :destroy
 
   def new
+    flash[:notice] = "asdaasd"
   end
 
   def create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
       user.update(time_zone: params[:time_zone]) if user.has_default_time_zone?
       sign_in(user)
       flash[:notice] = "Welcome back!"
-      redirect_to root_path
+      redirect_to params[:dest] || root_path
     else
       user = User.new
       user.errors.add(:base, "Invalid email or password")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,6 @@ class SessionsController < ApplicationController
   before_action :require_no_user!, except: :destroy
 
   def new
-    flash[:notice] = "asdaasd"
   end
 
   def create

--- a/app/javascript/controllers/book_selection_controller.js
+++ b/app/javascript/controllers/book_selection_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
-const BORDER_COLOR = "border-red-400"
-const BG_COLOR = "bg-red-50"
+const BORDER_COLOR = "border-sky-500"
+const BG_COLOR = "bg-sky-50"
 // Connects to data-controller="book-selection"
 export default class extends Controller {
   static targets = ["bookList","trueOption", "falseOption"];

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
       this.element.classList.add("active");
     });
 
-    // setTimeout(() => this.close(), 5000);
+    setTimeout(() => this.close(), 5000);
   }
 
   close() {

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
       this.element.classList.add("active");
     });
 
-    setTimeout(() => this.close(), 5000);
+    // setTimeout(() => this.close(), 5000);
   }
 
   close() {

--- a/app/models/reading_log.rb
+++ b/app/models/reading_log.rb
@@ -12,10 +12,12 @@ class ReadingLog < ApplicationRecord
   before_validation :autoset_slug, on: :create, unless: -> { template_reading_log_id.present? }
 
   validate :check_template_reading_log_id
+  before_validation :autoset_is_group_reading_log
 
-
-  def is_group_reading_log?
-    template_reading_log_id.present? || child_reading_logs.exists?
+  def autoset_is_group_reading_log
+    if template_reading_log_id.present?
+      self.is_group_reading_log = true
+    end
   end
 
   def parent_reading_log_slug

--- a/app/models/reading_log.rb
+++ b/app/models/reading_log.rb
@@ -5,12 +5,22 @@ class ReadingLog < ApplicationRecord
   has_many :books, dependent: :destroy
   has_many :ordered_books, -> { order(position: :asc)}, dependent: :destroy, class_name: "Book"
   has_many :child_reading_logs, class_name: "ReadingLog", foreign_key: "template_reading_log_id", dependent: :destroy
-  belongs_to :template_reading_log, class_name: "ReadingLog", foreign_key: "template_reading_log_id"
+  belongs_to :template_reading_log, class_name: "ReadingLog", foreign_key: "template_reading_log_id",optional: true
+
   belongs_to :user
 
   before_validation :autoset_slug, on: :create, unless: -> { template_reading_log_id.present? }
 
   validate :check_template_reading_log_id
+
+
+  def is_group_reading_log?
+    template_reading_log_id.present? || child_reading_logs.exists?
+  end
+
+  def parent_reading_log_slug
+    slug || template_reading_log.slug
+  end
 
   def check_template_reading_log_id
     if template_reading_log_id

--- a/app/models/reading_log.rb
+++ b/app/models/reading_log.rb
@@ -31,10 +31,10 @@ class ReadingLog < ApplicationRecord
   end
 
   def autoset_slug
-    self.slug = generate_slug!
+    self.slug = self.generate_slug!
   end
 
-  def generate_slug!
+  def self.generate_slug!
     SecureRandom.alphanumeric(10)
   end
 

--- a/app/models/reading_log.rb
+++ b/app/models/reading_log.rb
@@ -1,14 +1,14 @@
 class ReadingLog < ApplicationRecord
-  validates :name, :slug, presence: true
+  validates :name, presence: true
   validates :template_reading_log_id, uniqueness: { scope: :user_id }, allow_nil: true
   normalizes :name, with: ->(name) { name.strip }
   has_many :books, dependent: :destroy
   has_many :ordered_books, -> { order(position: :asc)}, dependent: :destroy, class_name: "Book"
-  has_many :child_reading_logs, class_name: "ReadingLog", foreign_key: "template_reading_log_id"
-  has_one :template_reading_log, class_name: "ReadingLog", foreign_key: "template_reading_log_id"
+  has_many :child_reading_logs, class_name: "ReadingLog", foreign_key: "template_reading_log_id", dependent: :destroy
+  belongs_to :template_reading_log, class_name: "ReadingLog", foreign_key: "template_reading_log_id"
   belongs_to :user
 
-  before_validation :autoset_slug, on: :create
+  before_validation :autoset_slug, on: :create, unless: -> { template_reading_log_id.present? }
 
   validate :check_template_reading_log_id
 
@@ -50,7 +50,7 @@ class ReadingLog < ApplicationRecord
   end
 
   def autoset_slug
-    self.slug = self.generate_slug!
+    self.slug = ReadingLog.generate_slug!
   end
 
   def self.generate_slug!

--- a/app/models/reading_log.rb
+++ b/app/models/reading_log.rb
@@ -1,9 +1,11 @@
 class ReadingLog < ApplicationRecord
-  validates :name, presence: true
+  validates :name, :slug, presence: true
   normalizes :name, with: ->(name) { name.strip }
   has_many :books, dependent: :destroy
   has_many :ordered_books, -> { order(position: :asc)}, dependent: :destroy, class_name: "Book"
   belongs_to :user
+
+  before_validation :autoset_slug, on: :create
 
   before_update :update_completed_at, if: :completed_books_count_changed?
   scope :complete, -> { where.not(completed_at: nil)}
@@ -26,6 +28,14 @@ class ReadingLog < ApplicationRecord
 
   def completed?
     completed_at.present?
+  end
+
+  def autoset_slug
+    self.slug = generate_slug!
+  end
+
+  def generate_slug!
+    SecureRandom.alphanumeric(10)
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
       </main>
     <% else  %>
       <%= render "shared/flash", custom_top_class: "!top-10" %>
-      <main class="p-5 mt-16 mb-10">
+      <main class="p-5 mb-10">
         <%= yield %>
       </main>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <% end %>
   </head>
 
-  <body class="<%= "bg-white sm:bg-neutral-50 flex-col pb-16 #{request.path == root_path || request.path == reading_logs_path ? 'sm:mt-12' : 'sm:mt-0'}" if user_signed_in? %>">
+  <body class="<%= 'bg-white sm:bg-neutral-50' if controller_name == "reading_logs" && action_name == "invite" %> <%= "bg-white sm:bg-neutral-50 flex-col pb-16 #{request.path == root_path || request.path == reading_logs_path ? 'sm:mt-12' : 'sm:mt-0'}" if user_signed_in? %>">
     <% if user_signed_in? %>
       <div id="flash">
         <%= render "shared/flash" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
         <%= yield %>
       </main>
     <% else  %>
-      <%= render "shared/flash", custom_top_class: "!top-10" %>
+      <%= render "shared/flash", custom_top_class: "!top-8" %>
       <main class="p-5 mb-10">
         <%= yield %>
       </main>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -2,7 +2,7 @@
 <%= render(AuthHeaderComponent.new(title: "Reset your password", description: "Set a new password for your account.")) %>
 
 <%= render(FormWrapperComponent.new) do |form_card| %>
-  <%= form_with model: @user, url: password_reset_path(token: params[:token]) do |form| %>
+  <%= form_with model: @user, url: password_reset_path(token: params[:token]), data: { turbo: false} do |form| %>
     <%= render(FormErrorsComponent.new(errors: @errors)) %>
 
     <%= render(FieldContainerComponent.new) do %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -2,7 +2,7 @@
 <%= render(AuthHeaderComponent.new(title: "Reset your password", description: "Enter your email and we'll send you reset instructions.")) %>
 
 <%= render(FormWrapperComponent.new) do |form_card| %>
-  <%= form_with model: @user, url: password_reset_path do |form| %>
+  <%= form_with model: @user, url: password_reset_path, data: { turbo: false } do |form| %>
     <%= render(FieldContainerComponent.new) do %>
       <%= render(LabelComponent.new(for_attribute: "email", form: form)) %>
       <%= render(InputComponent.new(type: "email", form: form, id_and_name: "email", required: true)) %>

--- a/app/views/reading_logs/_all_books_header.html.erb
+++ b/app/views/reading_logs/_all_books_header.html.erb
@@ -1,3 +1,3 @@
 <div class="relative">
-  <div class="border-b-2 border-red-700 mx-auto"></div>
+  <div class="-mx-5 border-b-2 border-red-700 md:mx-auto"></div>
 </div>

--- a/app/views/reading_logs/_reading_log.html.erb
+++ b/app/views/reading_logs/_reading_log.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="text-right">
     <% if reading_log.is_group_reading_log? %>
-      <p class="bg-red-500">group reading log</p>
+      <p class="bg-red-500 rounded-md text-white p-1">group reading log</p>
     <% end %>
     <% if @has_completed_status %>
       <div class="items-end flex flex-col justify-end">

--- a/app/views/reading_logs/_reading_log.html.erb
+++ b/app/views/reading_logs/_reading_log.html.erb
@@ -11,6 +11,9 @@
     <% end %>
   </div>
   <div class="text-right">
+    <% if reading_log.is_group_reading_log? %>
+      <p class="bg-red-500">group reading log</p>
+    <% end %>
     <% if @has_completed_status %>
       <div class="items-end flex flex-col justify-end">
         <div class="flex space-x-3 items-center">

--- a/app/views/reading_logs/_stats.html.erb
+++ b/app/views/reading_logs/_stats.html.erb
@@ -1,12 +1,16 @@
-<div class="bg-neutral-100 mb-4">
-  <% if reading_log.user == current_user %>
-    <div class="font-semibold text-red-600"><%= reading_log.user.full_name %> (you)</div>
-  <% else %>
-    <div class="font-semibold black"><%= reading_log.user.full_name %></div>
-  <% end %>
-
-  <div>
-    <span><%= reading_log.completed_book_percentage %>%</span>
-    <span><%= reading_log.completed_books_count %>/<%= reading_log.books_count %></span>
+<div class="text-left mb-4 p-5">
+  <div class="flex justify-between items-center">
+    <% if reading_log.user == current_user %>
+      <div class="font-semibold text-red-600"><%= reading_log.user.full_name %> (you)</div>
+    <% else %>
+      <div class="font-semibold black"><%= reading_log.user.full_name %></div>
+    <% end %>
+    <div>
+      <span><%= reading_log.completed_book_percentage %>%</span>
+      <span><%= reading_log.completed_books_count %>/<%= reading_log.books_count %></span>
+    </div>
+  </div>
+  <div class=" bg-gray-100 h-[8px] rounded-lg w-full group-hover:bg-gray-200">
+    <div class="bg-emerald-500 w-full h-full rounded-full" style="width:<%= reading_log.completed_book_percentage %>%"></div>
   </div>
 </div>

--- a/app/views/reading_logs/_stats.html.erb
+++ b/app/views/reading_logs/_stats.html.erb
@@ -1,0 +1,12 @@
+<div class="bg-neutral-100 mb-4">
+  <% if reading_log.user == current_user %>
+    <div class="font-semibold text-red-600"><%= reading_log.user.full_name %> (you)</div>
+  <% else %>
+    <div class="font-semibold black"><%= reading_log.user.full_name %></div>
+  <% end %>
+
+  <div>
+    <span><%= reading_log.completed_book_percentage %>%</span>
+    <span><%= reading_log.completed_books_count %>/<%= reading_log.books_count %></span>
+  </div>
+</div>

--- a/app/views/reading_logs/_stats.html.erb
+++ b/app/views/reading_logs/_stats.html.erb
@@ -1,11 +1,11 @@
-<div class="text-left mb-4 p-5">
-  <div class="flex justify-between items-center">
+<div class="text-left mb-6">
+  <div class="mb-2 flex justify-between items-center">
     <% if reading_log.user == current_user %>
-      <div class="font-semibold text-red-600"><%= reading_log.user.full_name %> (you)</div>
+      <div class="font-semibold text-red-600"><%= reading_log.user.full_name %></div>
     <% else %>
       <div class="font-semibold black"><%= reading_log.user.full_name %></div>
     <% end %>
-    <div>
+    <div class="text-sm space-x-3">
       <span><%= reading_log.completed_book_percentage %>%</span>
       <span><%= reading_log.completed_books_count %>/<%= reading_log.books_count %></span>
     </div>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -1,0 +1,9 @@
+<div class="text-center mt-20">
+  <% if @reading_log.present? %>
+    <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
+    <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
+    <%= link_to "Click here to join", root_path, class: "btn btn--primary" %>
+  <% else %>
+    <p>Sorry, that reading log doesn't exist.</p>
+  <% end %>
+</div>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -3,10 +3,13 @@
     <% if @reading_log.present? %>
       <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
       <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
-      <% iff @is_reading_log_owner %>
-        <p class="">You are the owner of this reading log, share this link with others!</p>
+      <% if @is_reading_log_owner %>
+        <p class="mb-6">You are the owner of this reading log, share this link with others!</p>
+        <%= link_to "Go to Reading Log", reading_log_path(@reading_log), class: "w-fit btn btn--primary" %>
       <% elsif @is_reading_log_member %>
-        <p class="">You are already part of this reading log, share this link with others!</p>
+        <p class="mb-6">You are already part of this reading log, share this link with others!</p>
+        <%= link_to "Go to Reading Log", reading_log_path(@reading_log), class: "w-fit btn btn--primary" %>
+      <% else %>
         <%= link_to "Join Reading Log", join_reading_log_invite_path(@reading_log.slug), class: "w-fit btn btn--primary" %>
       <% end %>
     <% else %>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -3,9 +3,10 @@
     <% if @reading_log.present? %>
       <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
       <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
-      <%  @is_reading_log_member %>
       <% if @is_reading_log_member %>
         <p class="">You are already part of this reading log, share this link with others!</p>
+      <% elsif @is_reading_log_owner %>
+        <p class="">You are the owner of this reading log, share this link with others!</p>
       <% else %>
         <%= link_to "Join Reading Log", join_reading_log_invite_path(@reading_log.slug), class: "w-fit btn btn--primary" %>
       <% end %>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -2,7 +2,12 @@
   <% if @reading_log.present? %>
     <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
     <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
-    <%= link_to "Click here to join", root_path, class: "btn btn--primary" %>
+    <%  @is_reading_log_member %>
+    <% if @is_reading_log_member %>
+      <p class="">You are already part of this reading log</p>
+    <% else %>
+      <%= button_to "Join Reading Log", root_path, method: :get, class: "w-fit btn btn--primary" %>
+    <% end %>
   <% else %>
     <p>Sorry, that reading log doesn't exist.</p>
   <% end %>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -1,14 +1,16 @@
-<div class="text-center mt-20">
-  <% if @reading_log.present? %>
-    <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
-    <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
-    <%  @is_reading_log_member %>
-    <% if @is_reading_log_member %>
-      <p class="">You are already part of this reading log</p>
+<%= render(CardWrapperComponent.new(custom_classes: "mt-14 mb-8")) do %>
+  <div class="text-center p-5">
+    <% if @reading_log.present? %>
+      <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
+      <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
+      <%  @is_reading_log_member %>
+      <% if @is_reading_log_member %>
+        <p class="">You are already part of this reading log, share this link with others!</p>
+      <% else %>
+        <%= button_to "Join Reading Log", root_path, method: :get, class: "w-fit btn btn--primary" %>
+      <% end %>
     <% else %>
-      <%= button_to "Join Reading Log", root_path, method: :get, class: "w-fit btn btn--primary" %>
+      <p>Sorry, that reading log doesn't exist.</p>
     <% end %>
-  <% else %>
-    <p>Sorry, that reading log doesn't exist.</p>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -7,7 +7,7 @@
       <% if @is_reading_log_member %>
         <p class="">You are already part of this reading log, share this link with others!</p>
       <% else %>
-        <%= button_to "Join Reading Log", root_path, method: :get, class: "w-fit btn btn--primary" %>
+        <%= link_to "Join Reading Log", join_reading_log_invite_path(@reading_log.slug), class: "w-fit btn btn--primary" %>
       <% end %>
     <% else %>
       <p>Sorry, that reading log doesn't exist.</p>

--- a/app/views/reading_logs/invite.html.erb
+++ b/app/views/reading_logs/invite.html.erb
@@ -3,11 +3,10 @@
     <% if @reading_log.present? %>
       <h1 class="text-2xl mb-3">You've been invited to join this Reading Log</h1>
       <h1 class="font-semibold text-4xl mb-8"><%= @reading_log.name %></h1>
-      <% if @is_reading_log_member %>
-        <p class="">You are already part of this reading log, share this link with others!</p>
-      <% elsif @is_reading_log_owner %>
+      <% iff @is_reading_log_owner %>
         <p class="">You are the owner of this reading log, share this link with others!</p>
-      <% else %>
+      <% elsif @is_reading_log_member %>
+        <p class="">You are already part of this reading log, share this link with others!</p>
         <%= link_to "Join Reading Log", join_reading_log_invite_path(@reading_log.slug), class: "w-fit btn btn--primary" %>
       <% end %>
     <% else %>

--- a/app/views/reading_logs/join_invite.html.erb
+++ b/app/views/reading_logs/join_invite.html.erb
@@ -1,0 +1,1 @@
+Handle invite logic here and redirect

--- a/app/views/reading_logs/join_invite.html.erb
+++ b/app/views/reading_logs/join_invite.html.erb
@@ -1,1 +1,1 @@
-Handle invite logic here and redirect
+<%= render(LoadingSpinnerComponent.new) %>

--- a/app/views/reading_logs/new.html.erb
+++ b/app/views/reading_logs/new.html.erb
@@ -21,14 +21,14 @@
 
         <%= render(FieldContainerComponent.new(custom_classes: "space-y-3")) do %>
           <div data-book-selection-target="trueOption" class="w-full flex items-center ps-4 border rounded-lg">
-            <%= form.radio_button :is_entire_bible, true, data: { action: "book-selection#toggleRadio"}, required: true, class: "w-5 h-5 text-red-500 bg-gray-100 border-gray-300 focus:ring-red-500 focus:ring-2" %>
+            <%= form.radio_button :is_entire_bible, true, data: { action: "book-selection#toggleRadio"}, required: true, class: "w-5 h-5 text-sky-600 bg-gray-100 border-gray-300 focus:ring-sky-600 focus:ring-2" %>
             <%= form.label :is_entire_bible_true, "Entire Bible", class: "cursor-pointer w-full py-4 ms-4 text-gray-900" %>
           </div>
           <div
             data-book-selection-target="falseOption"
             class="w-full flex flex-col ps-4 border rounded-lg">
             <div class="flex items-center">
-              <%= form.radio_button :is_entire_bible, false, data: { action: "book-selection#toggleRadio"}, required: true, class: "w-5 h-5 text-red-500 bg-gray-100 border-gray-300 focus:ring-red-500 focus:ring-2" %>
+              <%= form.radio_button :is_entire_bible, false, data: { action: "book-selection#toggleRadio"}, required: true, class: "w-5 h-5 text-sky-600 bg-gray-100 border-gray-300 focus:ring-sky-600 focus:ring-2" %>
               <%= form.label :is_entire_bible_false, "Specific Books", class: "cursor-pointer w-full py-4 ms-4 text-gray-900" %>
             </div>
             <div data-book-selection-target="bookList" class="<%= 'hidden' if form.object.is_entire_bible? %> mt-2">

--- a/app/views/reading_logs/settings.html.erb
+++ b/app/views/reading_logs/settings.html.erb
@@ -9,6 +9,10 @@
     <%= form_with model: @reading_log, data: { turbo_frame: "_top" } do |form| %>
       <%= render(FormErrorsComponent.new(errors: @errors)) %>
         <div class="">
+          <%= render(FieldContainerComponent.new(custom_classes: "mb-8")) do %>
+            <p class="mb-1 block text-sm">Invite</p>
+            <%= link_to reading_log_invite_url(@reading_log.slug), reading_log_invite_url(@reading_log.slug), class: "underline", target: "_blank", class: "bg-neutral-100 rounded-md p-1.5 " %>
+          <% end %>
           <%= render(FieldContainerComponent.new(custom_classes: "md:!mb-0 flex-1 w-full md:w-auto")) do %>
             <%= render(LabelComponent.new(for_attribute: "name", form: form)) %>
             <%= render(InputComponent.new(type: "text", form: form, id_and_name: "name", required: true, custom_classes: "")) %>

--- a/app/views/reading_logs/settings.html.erb
+++ b/app/views/reading_logs/settings.html.erb
@@ -11,11 +11,14 @@
         <div class="">
           <%= render(FieldContainerComponent.new(custom_classes: "mb-8")) do %>
             <p class="mb-1 block text-sm">Invite</p>
-            <%= link_to reading_log_invite_url(@reading_log.slug), reading_log_invite_url(@reading_log.slug), class: "underline", target: "_blank", class: "bg-neutral-100 rounded-md p-1.5 " %>
+            <%= link_to reading_log_invite_url(@reading_log.parent_reading_log_slug), reading_log_invite_url(@reading_log.parent_reading_log_slug), class: "underline", target: "_blank", class: "bg-neutral-100 rounded-md p-1.5 " %>
           <% end %>
           <%= render(FieldContainerComponent.new(custom_classes: "md:!mb-0 flex-1 w-full md:w-auto")) do %>
             <%= render(LabelComponent.new(for_attribute: "name", form: form)) %>
-            <%= render(InputComponent.new(type: "text", form: form, id_and_name: "name", required: true, custom_classes: "")) %>
+            <%= render(InputComponent.new(type: "text", form: form, id_and_name: "name", required: true, custom_classes: @reading_log.template_reading_log_id.present? ? 'bg-neutral-100' : '', disabled: @reading_log.template_reading_log_id.present?)) %>
+            <% if @reading_log.template_reading_log_id.present? %>
+              <div>Only the owner of this reading log can update the name</p>
+            <% end %>
           <% end %>
           <div class="flex sm:items-center sm:space-y-0 space-y-2 items-start mt-8 sm:justify-between flex-col sm:flex-row">
             <p class="font-semibold text-subheading">Reminders</p>

--- a/app/views/reading_logs/show.html.erb
+++ b/app/views/reading_logs/show.html.erb
@@ -20,14 +20,15 @@
     <% if @reading_log.is_group_reading_log? %>
       <div class="border">
         <p class="font-semibold text-xl">Reading group</p>
+          <%= render "stats", reading_log: @reading_log %>
          <% if @reading_log.template_reading_log_id.present? %>
-            <div><%= @reading_log.template_reading_log.user.full_name %></div>
+            <%= render "stats", reading_log: @reading_log.template_reading_log %>
             <% @reading_log.template_reading_log.child_reading_logs.where.not(user: current_user).each do |child_reading_log| %>
-              <div><%= child_reading_log.user.full_name %></div>
+              <%= render "stats", reading_log: child_reading_log %>
             <% end %>
          <% else %>
           <% @reading_log.child_reading_logs.each do |child_reading_log| %>
-            <div><%= child_reading_log.user.full_name %></div>
+              <%= render "stats", reading_log: child_reading_log %>
           <% end %>
          <% end %>
       </div>

--- a/app/views/reading_logs/show.html.erb
+++ b/app/views/reading_logs/show.html.erb
@@ -18,7 +18,7 @@
   <div class="text-center mb-11 sm:mb-6">
 
     <% if @reading_log.is_group_reading_log? %>
-      <div class="border">
+      <div class="border p-1">
         <p class="font-semibold text-xl">Reading group</p>
           <%= render "stats", reading_log: @reading_log %>
          <% if @reading_log.template_reading_log_id.present? %>

--- a/app/views/reading_logs/show.html.erb
+++ b/app/views/reading_logs/show.html.erb
@@ -18,7 +18,7 @@
   <div class="text-center mb-11 sm:mb-6">
 
     <% if @reading_log.is_group_reading_log? %>
-      <div class="border p-1">
+      <div class="border p-5 rounded-lg mb-5">
         <p class="font-semibold text-xl">Reading group</p>
           <%= render "stats", reading_log: @reading_log %>
          <% if @reading_log.template_reading_log_id.present? %>

--- a/app/views/reading_logs/show.html.erb
+++ b/app/views/reading_logs/show.html.erb
@@ -16,6 +16,22 @@
 <%= turbo_frame_tag "settings_form" %>
 <%= render(CardWrapperComponent.new(custom_classes: "pb-8")) do %>
   <div class="text-center mb-11 sm:mb-6">
+
+    <% if @reading_log.is_group_reading_log? %>
+      <div class="border">
+        <p class="font-semibold text-xl">Reading group</p>
+         <% if @reading_log.template_reading_log_id.present? %>
+            <div><%= @reading_log.template_reading_log.user.full_name %></div>
+            <% @reading_log.template_reading_log.child_reading_logs.where.not(user: current_user).each do |child_reading_log| %>
+              <div><%= child_reading_log.user.full_name %></div>
+            <% end %>
+         <% else %>
+          <% @reading_log.child_reading_logs.each do |child_reading_log| %>
+            <div><%= child_reading_log.user.full_name %></div>
+          <% end %>
+         <% end %>
+      </div>
+    <% end %>
     <% if @reading_log.completed? %>
       <div class="mx-auto mb-3 w-fit mt-0.5 flex items-center space-x-1.5 text-base font-medium text-emerald-700 bg-emerald-100  py-1 px-3 rounded-lg">
         <svg class="w-5 h-5 stroke-emerald-700" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -4,7 +4,7 @@
   <%= render(AuthHeaderComponent.new(title: "Welcome!", description: "Sign up to Bible Reading Log")) %>
 
   <%= render(FormWrapperComponent.new) do |form_card| %>
-    <%= form_with model: @user, url: sign_up_path, data: { controller: "time-zone" } do |form| %>
+    <%= form_with model: @user, url: sign_up_path, data: { turbo: false, controller: "time-zone" } do |form| %>
       <input type="hidden" name="_replyto" />
 			<%= render(FormErrorsComponent.new(errors: @errors)) %>
       <%= form.hidden_field :time_zone, data: {time_zone_target: "timeZoneField"} %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,7 +3,7 @@
 <%= render(AuthHeaderComponent.new(title: "Welcome Back.", description: "Sign in to Bible Reading Log")) %>
 
 <%= render(FormWrapperComponent.new) do |form_card| %>
-  <%= form_with model: @user, url: sign_in_path, data: { turbo: false, controller: "time-zone" } do |form| %>
+  <%= form_with model: @user, url: sign_in_path(dest: params[:dest]), data: { turbo: false, controller: "time-zone" } do |form| %>
     <%= render(FormErrorsComponent.new(errors: @errors)) %>
     <%= form.hidden_field :time_zone, data: {time_zone_target: "timeZoneField"} %>
 

--- a/app/views/users/email_confirmation.html.erb
+++ b/app/views/users/email_confirmation.html.erb
@@ -1,11 +1,17 @@
 <% render_title "Email Confirmation" %>
-<div>
-  <div class="-mt-2 mb-8  px-5 py-4 rounded bg-sky-100 border border-sky-300 text-sky-900">
-    <p>Confirmation email sent to <span class="font-medium underline"><%= current_user.email %></span></p>
-  </div>
-  <%= render(HeadingComponent.new(title: "Verify Your Email Address")) %>
+
+<%= render(CardWrapperComponent.new(custom_classes: "mt-4 sm:mt-14 mb-0")) do %>
   <div>
-    <p class="mt-5 mb-8">We have sent an email to you for verification. Please click on the link provided to confirm your email. If you don't receive an email within a few minutes, please try again.</div>
-    <%= button_to "Resend email confirmation", resend_email_confirmation_path, method: :post, class: "btn btn--slim text-sm w-auto" %>
+    <div class="-mt-2 mb-8  px-5 py-4 rounded bg-sky-100  text-sky-900">
+      <p>Confirmation email sent to <span class="font-medium underline"><%= current_user.email %></span></p>
+    </div>
+    <%= render(HeadingComponent.new(title: "Verify Your Email Address")) %>
+    <div>
+      <p class="mt-5 mb-8">We have sent an email to you for verification. Please click on the link provided to confirm your email. If you don't receive an email within a few minutes, please try again.</div>
+      <%= button_to "Resend email confirmation", resend_email_confirmation_path, method: :post, class: "btn btn--slim text-sm w-auto" %>
+    </div>
+    <%= button_to sign_out_path, method: :delete, class: "", form: {class: "mt-4 text-sm underline justify-end w-full flex"  }, data: { dropdown_target: "menuItem" } do %>
+      <span class="">Log out</span>
+    <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/users/verify_email_confirmation_token.html.erb
+++ b/app/views/users/verify_email_confirmation_token.html.erb
@@ -1,1 +1,1 @@
-<p>Verifying your email...</p>
+<%= render(LoadingSpinnerComponent.new) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "reading_logs#index"
 
-  resources :reading_logs, except: :edit do
+  resources :reading_logs, except: [:index, :edit] do
     member do
       get "row"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   end
 
   get "/r/:slug", to: "reading_logs#invite", as: :reading_log_invite
+  get "/r/:slug/join", to: "reading_logs#join_invite", as: :join_reading_log_invite
   get "sign_in", to: "sessions#new"
   post 'sign_in', to: "sessions#create"
   get "sign_up", to: "registrations#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/r/:slug", to: "reading_logs#invite", as: :reading_log_invite
   get "sign_in", to: "sessions#new"
   post 'sign_in', to: "sessions#create"
   get "sign_up", to: "registrations#new"

--- a/db/migrate/20240518004404_add_slug_to_reading_logs.rb
+++ b/db/migrate/20240518004404_add_slug_to_reading_logs.rb
@@ -1,0 +1,6 @@
+class AddSlugToReadingLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reading_logs, :slug, :string
+    add_index :reading_logs, :slug, unique: true
+  end
+end

--- a/db/migrate/20240518012619_add_reference_to_template_reading_logs.rb
+++ b/db/migrate/20240518012619_add_reference_to_template_reading_logs.rb
@@ -1,0 +1,6 @@
+class AddReferenceToTemplateReadingLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :reading_logs, :template_reading_log, foreign_key: { to_table: :reading_logs }, index: false
+    add_index :reading_logs, [:template_reading_log_id, :user_id], unique: true
+  end
+end

--- a/db/migrate/20240519004420_add_is_group_reading_log_to_reading_log.rb
+++ b/db/migrate/20240519004420_add_is_group_reading_log_to_reading_log.rb
@@ -1,0 +1,5 @@
+class AddIsGroupReadingLogToReadingLog < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reading_logs, :is_group_reading_log, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_18_012619) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_19_004420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_18_012619) do
     t.integer "books_count", null: false
     t.string "slug"
     t.bigint "template_reading_log_id"
+    t.boolean "is_group_reading_log", default: false, null: false
     t.index ["completed_at"], name: "index_reading_logs_on_completed_at"
     t.index ["is_reminder_enabled"], name: "index_reading_logs_on_is_reminder_enabled"
     t.index ["last_sent_at"], name: "index_reading_logs_on_last_sent_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_12_182707) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_18_004404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,10 +49,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_12_182707) do
     t.datetime "last_sent_at"
     t.datetime "reminder_scheduled_at"
     t.integer "books_count", null: false
+    t.string "slug"
     t.index ["completed_at"], name: "index_reading_logs_on_completed_at"
     t.index ["is_reminder_enabled"], name: "index_reading_logs_on_is_reminder_enabled"
     t.index ["last_sent_at"], name: "index_reading_logs_on_last_sent_at"
     t.index ["reminder_scheduled_at"], name: "index_reading_logs_on_reminder_scheduled_at"
+    t.index ["slug"], name: "index_reading_logs_on_slug", unique: true
     t.index ["user_id"], name: "index_reading_logs_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_18_004404) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_18_012619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,11 +50,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_18_004404) do
     t.datetime "reminder_scheduled_at"
     t.integer "books_count", null: false
     t.string "slug"
+    t.bigint "template_reading_log_id"
     t.index ["completed_at"], name: "index_reading_logs_on_completed_at"
     t.index ["is_reminder_enabled"], name: "index_reading_logs_on_is_reminder_enabled"
     t.index ["last_sent_at"], name: "index_reading_logs_on_last_sent_at"
     t.index ["reminder_scheduled_at"], name: "index_reading_logs_on_reminder_scheduled_at"
     t.index ["slug"], name: "index_reading_logs_on_slug", unique: true
+    t.index ["template_reading_log_id", "user_id"], name: "index_reading_logs_on_template_reading_log_id_and_user_id", unique: true
     t.index ["user_id"], name: "index_reading_logs_on_user_id"
   end
 
@@ -74,5 +76,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_18_004404) do
   end
 
   add_foreign_key "books", "reading_logs"
+  add_foreign_key "reading_logs", "reading_logs", column: "template_reading_log_id"
   add_foreign_key "reading_logs", "users"
 end


### PR DESCRIPTION
Adds the the concept of a group reading log where users can see other user's completion stats if they  are in the group. All reading logs in a group have the same name and books.

1. Each reading log generates a unique slug on creation that is used on the new route that allows users to join that reading log.
2. When USER B joins USER A's reading log, USER A's reading log's (and associated books) are duplicated over to USER B.
3. USER B's new reading log belongs to USER A's reading log (template_reading_log_id). In other words: the USER A's log has many children reading logs, the model references itself.

Notes:
- A `slug` is not auto-generated when the record has a `template_reading_log_id` present.
- Sets `is_group_reading_log` to note which reading logs have children reading logs (to make it easy to distinguish in the UI quickly instead of relying on a has_many query).
- Added a way to redirect a user back to the intended page if they initially visited the page while logged out but were directed to the sign-in because they needed to be signed in.

https://github.com/pkayokay/biblereadinglog/assets/13375749/99341dde-c3cd-4d8d-8ee2-7e272822e3b4

